### PR TITLE
fix(schema): resolve array items via getFieldSchema

### DIFF
--- a/src/class-schema.ts
+++ b/src/class-schema.ts
@@ -110,7 +110,7 @@ export class ClassSchema<T extends SchemaClass = SchemaClass> {
     else {
       const Class = fieldType[0] as Class<unknown>;
       schema.type = 'array';
-      schema.items ??= { $ref: this.getSchemaId(Class) };
+      schema.items ??= this.getFieldSchema(Class);
     }
 
     return schema;

--- a/tests/class-schema.spec.ts
+++ b/tests/class-schema.spec.ts
@@ -410,4 +410,24 @@ describe('ClassSchema', () => {
       });
     });
   });
+
+  describe('primitive arrays', () => {
+    // Uses the default (absolute) `class-schema:<name>-<n>` `$id`, which is where a bare `$ref: 'String'`
+    // for array items fails to resolve. Items must inline their primitive `type` instead.
+    @Schema()
+    class WithPrimitiveArray {
+      @Field(() => [String])
+      tags: string[];
+
+      @Field(() => [Integer], { optional: true })
+      counts?: number[];
+    }
+
+    it('should inline primitive array items instead of emitting an unresolvable $ref', () => {
+      const schema = ClassSchema.generate(WithPrimitiveArray);
+      expect(schema.properties?.tags).toStrictEqual({ type: 'array', items: { type: 'string' } });
+      expect(schema.properties?.counts).toStrictEqual({ type: 'array', items: { type: 'integer' } });
+      expect(schema.definitions).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
$ref: getSchemaId(Class) assumed every array item type has a registered schema id. Primitive types (String, Integer, ...) don't, so arrays like string[] emitted an unresolvable $ref instead of an inline { type: 'string' } schema. getFieldSchema already handles the primitive-vs-class distinction for scalar fields, so reuse it here.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows the guidelines described [here](../CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Performance or Refactoring
- [ ] Build, CI related changes or Documentation
- [ ] Tests and Examples
- [ ] Other...

If Other Please describe:

## What is the current behavior?

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Notes for Reviewers
