### PR TITLE
refactor(class-schema): Phase 1 — codegen hardening, engine split, nullable-ref fix

### DIFF
--- a/src/class-schema.ts
+++ b/src/class-schema.ts
@@ -31,6 +31,16 @@ export interface ClassSchemaOptions {
  */
 const primitiveTypes: Class<unknown>[] = [String, Number, Boolean, Object, Array];
 
+/** Maps the runtime type tokens to their JSON Schema `type`, including the library-defined `Integer` marker */
+const primitiveSchemaTypes = new Map<unknown, JSONSchemaType>([
+  [String, 'string'],
+  [Number, 'number'],
+  [Boolean, 'boolean'],
+  [Integer, 'integer'],
+  [Object, 'object'],
+  [Array, 'array'],
+]);
+
 export class ClassSchema<T extends SchemaClass = SchemaClass> {
   private readonly schema: ParsedSchema;
   private readonly options: ClassSchemaOptions;
@@ -68,7 +78,7 @@ export class ClassSchema<T extends SchemaClass = SchemaClass> {
 
   private getSchema(Class: EnumType | Class<unknown>): ParsedSchema {
     if (Class instanceof EnumType) return Class.toSchema();
-    if (primitiveTypes.includes(Class)) return { $id: Class.name, type: Class.name.toLowerCase() as JSONSchemaType };
+    if (primitiveTypes.includes(Class)) return { $id: Class.name, type: primitiveSchemaTypes.get(Class) as JSONSchemaType };
     const schema = Reflect.getMetadata(METADATA_KEYS.SCHEMA_OPTIONS, Class) as ParsedSchema | undefined;
     if (!schema) throw new Error(`Class '${Class.name}' is not a schema. Add the @Schema() to the class`);
     return structuredClone(schema);
@@ -100,17 +110,13 @@ export class ClassSchema<T extends SchemaClass = SchemaClass> {
       fieldType = getType();
     }
 
-    if (fieldType === String) schema.type = 'string';
-    else if (fieldType === Boolean) schema.type = 'boolean';
-    else if (fieldType === Number) schema.type = 'number';
-    else if (fieldType === Integer) schema.type = 'integer';
-    else if (fieldType === Object) schema.type = 'object';
-    else if (fieldType === Array) schema.type = 'array';
-    else if (!Array.isArray(fieldType)) schema.$ref ??= this.getSchemaId(fieldType);
+    const primitiveType = primitiveSchemaTypes.get(fieldType);
+    if (primitiveType) schema.type = primitiveType;
+    else if (!Array.isArray(fieldType)) schema.$ref = this.getSchemaId(fieldType);
     else {
       const Class = fieldType[0] as Class<unknown>;
       schema.type = 'array';
-      schema.items ??= this.getFieldSchema(Class);
+      schema.items = this.getFieldSchema(Class);
     }
 
     return schema;
@@ -118,47 +124,56 @@ export class ClassSchema<T extends SchemaClass = SchemaClass> {
 
   private populateSchema(schema: ParsedSchema, Class: Class<unknown>): void {
     if (schema.type !== 'object') return;
-    const instance = new Class();
+    this.applyExtraProperties(schema, Class);
+    this.applyComposition(schema, Class);
+    this.applyFields(schema, Class);
+  }
 
-    /** Adding the extra properties to the schema */
-    const extraProperties = Reflect.getMetadata(METADATA_KEYS.SCHEMA_EXTRA_PROPERTIES, Class) as Pick<SchemaOptions, 'additionalProperties' | 'patternProperties'>;
-    if (extraProperties) {
-      const { additionalProperties, patternProperties } = extraProperties;
-      if (typeof additionalProperties === 'boolean') schema.additionalProperties = additionalProperties;
-      else if (additionalProperties) schema.additionalProperties = this.getFieldSchema(additionalProperties);
+  /** Resolves the class-valued `additionalProperties`/`patternProperties` schema options into their JSON Schema form */
+  private applyExtraProperties(schema: ParsedSchema, Class: Class<unknown>): void {
+    const extraProperties = Reflect.getMetadata(METADATA_KEYS.SCHEMA_EXTRA_PROPERTIES, Class) as Pick<SchemaOptions, 'additionalProperties' | 'patternProperties'> | undefined;
+    if (!extraProperties) return;
 
-      if (patternProperties) {
-        schema.patternProperties ??= {};
-        for (const pattern in patternProperties) {
-          const Class = patternProperties[pattern] as Class<unknown>;
-          const patternSchema = this.getFieldSchema(Class);
-          schema.patternProperties[pattern] = patternSchema;
-        }
+    const { additionalProperties, patternProperties } = extraProperties;
+    if (typeof additionalProperties === 'boolean') schema.additionalProperties = additionalProperties;
+    else if (additionalProperties) schema.additionalProperties = this.getFieldSchema(additionalProperties);
+
+    if (patternProperties) {
+      schema.patternProperties ??= {};
+      for (const pattern in patternProperties) {
+        schema.patternProperties[pattern] = this.getFieldSchema(patternProperties[pattern] as Class<unknown>);
       }
     }
+  }
 
-    /** Adding the composed classes to the schema */
-    const composedMetadata = Reflect.getMetadata(METADATA_KEYS.COMPOSED_CLASS, Class) as SchemaComposerMetadata;
-    if (composedMetadata) {
-      const subSchemas = composedMetadata.classes.map(cls => this.getSchemaId(cls));
-      schema[composedMetadata.op] = subSchemas.map(id => ({ $ref: id }));
-      if (composedMetadata.discriminatorKey) {
-        const mapping: Record<string, string> = {};
-        for (const schemaName of subSchemas) {
-          const constValue = this.schema.definitions?.[schemaName]?.properties?.[composedMetadata.discriminatorKey]?.const;
-          mapping[constValue] = schemaName;
-        }
-        schema.discriminator = { propertyName: composedMetadata.discriminatorKey, mapping };
-      }
+  /** Expands a composed (`anyOf`/`oneOf`/discriminator) class into its keyword and discriminator mapping */
+  private applyComposition(schema: ParsedSchema, Class: Class<unknown>): void {
+    const composedMetadata = Reflect.getMetadata(METADATA_KEYS.COMPOSED_CLASS, Class) as SchemaComposerMetadata | undefined;
+    if (!composedMetadata) return;
+
+    const subSchemas = composedMetadata.classes.map(cls => this.getSchemaId(cls));
+    schema[composedMetadata.op] = subSchemas.map(id => ({ $ref: id }));
+    if (!composedMetadata.discriminatorKey) return;
+
+    const mapping: Record<string, string> = {};
+    for (const schemaName of subSchemas) {
+      const constValue = this.schema.definitions?.[schemaName]?.properties?.[composedMetadata.discriminatorKey]?.const;
+      mapping[constValue] = schemaName;
     }
+    schema.discriminator = { propertyName: composedMetadata.discriminatorKey, mapping };
+  }
 
-    /** Adding the object properties to the schema */
+  /** Builds the object `properties`, `required` list and `dependencies` from the decorated fields */
+  private applyFields(schema: ParsedSchema, Class: Class<unknown>): void {
     const fields: string[] = Reflect.getMetadata(METADATA_KEYS.SCHEMA_FIELDS, Class.prototype) ?? [];
+    if (fields.length === 0) return;
+    const instance = new Class() as Record<string, unknown>;
+
     for (const field of fields) {
       const fieldMetadata = Reflect.getMetadata(METADATA_KEYS.FIELD_OPTIONS, Class.prototype, field) as AnyFieldSchema;
       const { optional, requiredIf, nullable, ...fieldSchema } = fieldMetadata;
 
-      const instanceValue = (instance as Record<string, unknown>)[field];
+      const instanceValue = instance[field];
       const derivedSchema = this.getFieldSchema(Class, field);
       if (!schema.properties) schema.properties = {};
       if (nullable) derivedSchema.type = [derivedSchema.type as JSONSchemaType, 'null'];

--- a/src/class-schema.ts
+++ b/src/class-schema.ts
@@ -176,7 +176,7 @@ export class ClassSchema<T extends SchemaClass = SchemaClass> {
       const instanceValue = instance[field];
       const derivedSchema = this.getFieldSchema(Class, field);
       if (!schema.properties) schema.properties = {};
-      if (nullable) derivedSchema.type = [derivedSchema.type as JSONSchemaType, 'null'];
+      if (nullable) this.applyNullable(derivedSchema);
       if (instanceValue !== undefined) derivedSchema.default = instanceValue;
       schema.properties[field] = merge(derivedSchema, fieldSchema);
 
@@ -190,6 +190,16 @@ export class ClassSchema<T extends SchemaClass = SchemaClass> {
         schema.dependencies[requiredIf] = dependencies;
       }
     }
+  }
+
+  /** Applies the unified nullability rule: typed schemas gain a `null` type member, while `$ref`s become a nullable `anyOf` since a `$ref` cannot carry its own type */
+  private applyNullable(schema: JSONSchema): void {
+    if (schema.$ref) {
+      schema.anyOf = [{ $ref: schema.$ref }, { type: 'null' }];
+      delete schema.$ref;
+      return;
+    }
+    schema.type = [schema.type as JSONSchemaType, 'null'];
   }
 
   getId(): string {

--- a/src/enum-type.ts
+++ b/src/enum-type.ts
@@ -1,7 +1,7 @@
 /**
  * Importing npm packages
  */
-import { InternalError } from '@shadow-library/common';
+import { AppError } from '@shadow-library/common';
 
 /**
  * Importing user defined packages
@@ -27,10 +27,10 @@ export class EnumType<T extends string | number = string | number> {
   readonly options: EnumFieldSchema;
 
   private constructor(name: string, values: T[], options: EnumFieldSchema) {
-    if (values.length === 0) throw new InternalError('Enum must have at least one value');
+    if (values.length === 0) throw AppError.internal('Enum must have at least one value');
     const type = typeof values[0] as ValidEnumType;
     const isValidEnum = values.every(v => typeof v === type);
-    if (!isValidEnum) throw new InternalError('All enum values must be of the same type');
+    if (!isValidEnum) throw AppError.internal('All enum values must be of the same type');
 
     this.id = `class-schema:${name}-enum-${getCounterId()}`;
     this.type = type;

--- a/src/transformer-factory.ts
+++ b/src/transformer-factory.ts
@@ -3,7 +3,7 @@
  */
 import assert from 'node:assert';
 
-import { InternalError, MaybeNull } from '@shadow-library/common';
+import { AppError, MaybeNull } from '@shadow-library/common';
 
 /**
  * Importing user defined packages
@@ -97,7 +97,7 @@ export class TransformerFactory {
   }
 
   hasTransformableFields(schema: JSONSchema): boolean {
-    if (!ClassSchema.isBranded(schema)) throw new InternalError('Invalid schema: only schemas built with this package are supported');
+    if (!ClassSchema.isBranded(schema)) throw AppError.internal('Invalid schema: only schemas built with this package are supported');
     return this.hasTransformTargets(schema);
   }
 

--- a/src/transformer-factory.ts
+++ b/src/transformer-factory.ts
@@ -58,25 +58,19 @@ interface FieldDefinition {
   variants: Record<string, FieldVariantSpec>;
 }
 
-type Runtime = 'node' | 'deno' | 'bun';
-
 /**
  * Declaring the constants
  */
 const noop: Transformer = value => value;
-declare const Deno: any;
+
+/** Renders a bracketed member access so arbitrary keys (kebab-case, quotes, reserved words) stay valid in generated code */
+const member = (base: string, key: string | number): string => `${base}[${JSON.stringify(key.toString())}]`;
 
 export class TransformerFactory {
   private readonly context: ContextState;
 
   constructor(private readonly filter: FieldFilter) {
     this.context = { transformers: {}, schemas: {}, constructPath: (prefix, field) => (prefix ? `${prefix}.${field.toString()}` : field.toString()) };
-  }
-
-  private getRuntime(): Runtime {
-    if (typeof Bun !== 'undefined') return 'bun';
-    if (typeof Deno !== 'undefined') return 'deno';
-    return 'node';
   }
 
   private hasTransformTargets(schema: JSONSchema): boolean {
@@ -161,7 +155,7 @@ export class TransformerFactory {
         const variantSpec = validConstDiscriminator.variants[variant.$id];
         assert(variantSpec?.const !== undefined, 'Variant must have a const value for the discriminator field');
         const value = JSON.stringify(variantSpec.const);
-        const condition = `data.${validConstDiscriminator.name} === ${value}`;
+        const condition = `${member('data', validConstDiscriminator.name)} === ${value}`;
         discriminator.push({ condition, schemaId: variant.$id });
       }
 
@@ -175,7 +169,7 @@ export class TransformerFactory {
       if (typeDiscriminators.has(typeField.name)) continue;
       for (const schemaId in typeField.variants) {
         const variantSpec = typeField.variants[schemaId] as FieldVariantSpec;
-        const condition = `typeof data.${typeField.name} === '${variantSpec.type}'`;
+        const condition = `typeof ${member('data', typeField.name)} === ${JSON.stringify(variantSpec.type)}`;
         typeDiscriminators.set(schemaId, condition);
       }
     }
@@ -187,11 +181,11 @@ export class TransformerFactory {
     /** Trying to find a valid enum discriminator */
     const validEnumDiscriminator = fields.find(fieldDef => this.hasUniqueFieldValues(fieldDef, 'enum'));
     if (validEnumDiscriminator) {
+      const access = member('data', validEnumDiscriminator.name);
       for (const variant of variants) {
         const variantSpec = validEnumDiscriminator.variants[variant.$id] as FieldVariantSpec;
         assert(variantSpec?.enum !== undefined, 'Variant must have an enum value for the discriminator field');
-        let condition = `${JSON.stringify(variantSpec.enum)}.includes(data.${validEnumDiscriminator.name})`;
-        if (this.getRuntime() === 'bun') condition = variantSpec.enum.map(value => `data.${validEnumDiscriminator.name} === ${JSON.stringify(value)}`).join(' || ');
+        const condition = variantSpec.enum.map(value => `${access} === ${JSON.stringify(value)}`).join(' || ');
         discriminator.push({ condition, schemaId: variant.$id });
       }
 
@@ -207,7 +201,7 @@ export class TransformerFactory {
     this.context.schemas[schema.$id] = schema;
 
     let ops = '';
-    if (this.filter(schema)) ops += `data = action(data, this.schemas['${schema.$id}'], ctx);`;
+    if (this.filter(schema)) ops += `data = action(data, ${member('this.schemas', schema.$id)}, ctx);`;
 
     /** Handling root array schema */
     if (schema.type === 'array' && schema.items) {
@@ -217,13 +211,13 @@ export class TransformerFactory {
         ops += `
           if (Array.isArray(data)) {
             const getContext = (index) => ({ ...ctx, field: index.toString(), path: this.constructPath(ctx.prefix, index) });
-            data = data.map((value, index) => action(value, this.schemas['${schema.$id}'], getContext(index))).filter(value => value !== undefined);
+            data = data.map((value, index) => action(value, ${member('this.schemas', schema.$id)}, getContext(index))).filter(value => value !== undefined);
           }
         `;
       } else {
         ops += `
           if (Array.isArray(data)) {
-            const transformer = this.transformers['${schema.items.$ref}'];
+            const transformer = ${member('this.transformers', schema.items.$ref as string)};
             if (transformer) {
               const getContext = (index) => ({ ...ctx, prefix: this.constructPath(ctx.prefix, index) });
               data = data.map((value, index) => transformer(value, action, getContext(index))).filter(value => value !== undefined);
@@ -242,7 +236,7 @@ export class TransformerFactory {
         for (const { condition, schemaId } of discriminators) {
           ops += `
           if (${condition}) {
-            const transformer = this.transformers['${schemaId}'];
+            const transformer = ${member('this.transformers', schemaId)};
             if (transformer) data = transformer(data, action, ctx);
           }
         `;
@@ -251,7 +245,7 @@ export class TransformerFactory {
         for (const variant of variants) {
           ops += `
           {
-            const transformer = this.transformers['${variant.$id}'];
+            const transformer = ${member('this.transformers', variant.$id)};
             if (transformer) data = transformer(data, action, ctx);
           }
           `;
@@ -270,36 +264,38 @@ export class TransformerFactory {
       }
 
       for (const field of fields) {
+        const access = member('data', field);
         ops += `
-          if ('${field}' in data) {
-            const value = data.${field};
-            const childContext = { parent: data, root: ctx.root, field: '${field}', path: this.constructPath(ctx.prefix, '${field}') };
-            data.${field} = action(value, this.schemas['${schema.$id}'].properties.${field}, childContext);
-            if (data.${field} === undefined) delete data.${field};
+          if (${JSON.stringify(field)} in data) {
+            const value = ${access};
+            const childContext = { parent: data, root: ctx.root, field: ${JSON.stringify(field)}, path: this.constructPath(ctx.prefix, ${JSON.stringify(field)}) };
+            ${access} = action(value, ${member('this.schemas', schema.$id)}.properties[${JSON.stringify(field)}], childContext);
+            if (${access} === undefined) delete ${access};
           }
         `;
       }
 
       for (const field of refFields) {
+        const access = member('data', field);
         const refSchema = schema.properties[field] as JSONSchema;
         if (refSchema.type === 'array') {
           ops += `
-            if (Array.isArray(data.${field})) {
-              const transformer = this.transformers['${refSchema.items?.$ref}'];
+            if (Array.isArray(${access})) {
+              const transformer = ${member('this.transformers', refSchema.items?.$ref as string)};
               if (transformer) {
-                const getContext = (index) => ({ parent: data, root: ctx.root, prefix: this.constructPath(ctx.prefix, '${field}.' + index) });
-                data.${field} = data.${field}.map((value, index) => transformer(value, action, getContext(index))).filter(value => value !== undefined);
+                const getContext = (index) => ({ parent: data, root: ctx.root, prefix: this.constructPath(ctx.prefix, ${JSON.stringify(field + '.')} + index) });
+                ${access} = ${access}.map((value, index) => transformer(value, action, getContext(index))).filter(value => value !== undefined);
               }
             }
           `;
         } else {
           ops += `
-            if ('${field}' in data) {
-              const transformer = this.transformers['${refSchema.$ref}'];
+            if (${JSON.stringify(field)} in data) {
+              const transformer = ${member('this.transformers', refSchema.$ref as string)};
               if (transformer) {
-                const childContext = { parent: data, root: ctx.root, prefix: this.constructPath(ctx.prefix, '${field}') };
-                data.${field} = transformer(data.${field}, action, childContext);
-                if (data.${field} === undefined) delete data.${field};
+                const childContext = { parent: data, root: ctx.root, prefix: this.constructPath(ctx.prefix, ${JSON.stringify(field)}) };
+                ${access} = transformer(${access}, action, childContext);
+                if (${access} === undefined) delete ${access};
               }
             }
           `;

--- a/tests/class-schema.spec.ts
+++ b/tests/class-schema.spec.ts
@@ -430,4 +430,33 @@ describe('ClassSchema', () => {
       expect(schema.definitions).toBeUndefined();
     });
   });
+
+  describe('nullable fields', () => {
+    @Schema({ $id: NullableHost.name })
+    class NullableHost {
+      @Field(() => String, { nullable: true })
+      text: string | null;
+
+      @Field(() => Sample, { nullable: true })
+      ref: Sample | null;
+
+      @Field(() => [Sample], { nullable: true })
+      list: Sample[] | null;
+    }
+
+    it('should extend the type array for nullable primitive fields', () => {
+      const schema = ClassSchema.generate(NullableHost);
+      expect(schema.properties?.text).toStrictEqual({ type: ['string', 'null'] });
+    });
+
+    it('should wrap nullable $ref fields in a nullable anyOf instead of emitting an invalid type', () => {
+      const schema = ClassSchema.generate(NullableHost);
+      expect(schema.properties?.ref).toStrictEqual({ anyOf: [{ $ref: Sample.name }, { type: 'null' }] });
+    });
+
+    it('should extend the type array for nullable array fields', () => {
+      const schema = ClassSchema.generate(NullableHost);
+      expect(schema.properties?.list).toStrictEqual({ type: ['array', 'null'], items: { $ref: Sample.name } });
+    });
+  });
 });

--- a/tests/class-schema.spec.ts
+++ b/tests/class-schema.spec.ts
@@ -87,6 +87,8 @@ describe('ClassSchema', () => {
     @Field({ optional: true })
     size?: number;
 
+    // A scalar reference to a class declared later in a circular pair must stay `object`: under
+    // emitDecoratorMetadata, annotating it `Folder` emits a runtime reference before Folder exists.
     @Field(() => Folder)
     parent: object;
 
@@ -100,10 +102,10 @@ describe('ClassSchema', () => {
     name: string;
 
     @Field(() => [File])
-    files: File;
+    files: File[];
 
     @Field(() => [Folder])
-    folders: Folder;
+    folders: Folder[];
   }
 
   describe('isBranded', () => {

--- a/tests/enum-type.spec.ts
+++ b/tests/enum-type.spec.ts
@@ -3,7 +3,7 @@
  */
 import { describe, expect, it } from 'bun:test';
 
-import { InternalError } from '@shadow-library/common';
+import { AppError } from '@shadow-library/common';
 
 /**
  * Importing user defined packages
@@ -51,7 +51,7 @@ describe('EnumType', () => {
     });
 
     it('should throw error for mixed enum values', () => {
-      expect(() => EnumType.create('Mixed', ['active', 1, 'pending'] as any)).toThrow(InternalError);
+      expect(() => EnumType.create('Mixed', ['active', 1, 'pending'] as any)).toThrow(AppError);
     });
 
     it('should generate unique ids for different enums', () => {

--- a/tests/transformer-factory.spec.ts
+++ b/tests/transformer-factory.spec.ts
@@ -25,6 +25,43 @@ describe('TransformerFactory', () => {
     expect(() => transformer.compile({ $id: 'test', type: 'object', properties: {} })).toThrow(AppError);
   });
 
+  describe('codegen hardening', () => {
+    it('should transform fields whose keys are not valid identifiers', () => {
+      const schema = {
+        [BRAND]: true,
+        $id: 'KebabSchema',
+        type: 'object',
+        required: ['foo-bar', 'nested'],
+        properties: {
+          'foo-bar': { type: 'string', tagged: true },
+          nested: { $ref: 'Child' },
+        },
+        definitions: { Child: { $id: 'Child', type: 'object', properties: { 'a.b': { type: 'string', tagged: true } } } },
+      };
+
+      const factory = new TransformerFactory(fieldSchema => !!(fieldSchema as any).tagged);
+      const transformer = factory.compile(schema as any);
+      const result = transformer({ 'foo-bar': 'hello', nested: { 'a.b': 'world' } }, () => 'xxx');
+
+      expect(result).toStrictEqual({ 'foo-bar': 'xxx', nested: { 'a.b': 'xxx' } });
+    });
+
+    it('should transform schemas whose $id contains quotes and special characters', () => {
+      const schema = {
+        [BRAND]: true,
+        $id: `class-schema:oneOf?Classes=A'B,"C"`,
+        type: 'object',
+        required: ['value'],
+        properties: { value: { type: 'string', tagged: true } },
+      };
+
+      const factory = new TransformerFactory(fieldSchema => !!(fieldSchema as any).tagged);
+      const transformer = factory.compile(schema as any);
+
+      expect(transformer({ value: 'hello' }, () => 'xxx')).toStrictEqual({ value: 'xxx' });
+    });
+  });
+
   it('should create transforms for only required schema', () => {
     const schema = {
       [BRAND]: true,

--- a/tests/transformer-factory.spec.ts
+++ b/tests/transformer-factory.spec.ts
@@ -3,7 +3,7 @@
  */
 import { describe, expect, it, mock } from 'bun:test';
 
-import { InternalError } from '@shadow-library/common';
+import { AppError } from '@shadow-library/common';
 
 /**
  * Importing user defined packages
@@ -22,7 +22,7 @@ import { TransformerFactory } from '@shadow-library/class-schema';
 describe('TransformerFactory', () => {
   it('should throw error for custom schemas', () => {
     const transformer = new TransformerFactory(() => false);
-    expect(() => transformer.compile({ $id: 'test', type: 'object', properties: {} })).toThrow(InternalError);
+    expect(() => transformer.compile({ $id: 'test', type: 'object', properties: {} })).toThrow(AppError);
   });
 
   it('should create transforms for only required schema', () => {
@@ -205,7 +205,7 @@ describe('TransformerFactory', () => {
   describe('hasTransformableFields', () => {
     it('should throw error for non-branded schemas', () => {
       const factory = new TransformerFactory(schema => !!schema.tagged);
-      expect(() => factory.hasTransformableFields({ $id: 'test', type: 'object', properties: {} })).toThrow(InternalError);
+      expect(() => factory.hasTransformableFields({ $id: 'test', type: 'object', properties: {} })).toThrow(AppError);
     });
 
     it('should return true for schema with transformable field', () => {


### PR DESCRIPTION
## Phase 1 of the class-schema refactor plan

Foundation work from the approved refactor plan: internal hardening, a readability refactor, and the first correctness fix. **No public API changes.** All changes are guarded by the existing snapshot tests (now 120 passing, +5 new).

> **Note on the base:** this branch stacks on the local-only `feat_error-api-2` branch, so its first commit (`b8deace`, the unified-error-api migration) shows in this diff but is **pre-existing work, not part of this refactor**. Once `feat_error-api-2` is pushed, retarget this PR's base to it for a clean diff.

### Commits in this PR
| Commit | Type | What |
|--------|------|------|
| `refactor(transformer)` | hardening | Codegen now uses bracket access + `JSON.stringify` for all property/dict access, so kebab-case keys, reserved words, and quote-bearing `$id`s no longer break or inject code. Bun-specific enum branch removed in favour of a universal `===` chain. |
| `refactor(schema)` | readability | `populateSchema` split into `applyExtraProperties` / `applyComposition` / `applyFields`; duplicated primitive-type chains replaced with one shared lookup map; no-op `??=` idioms removed. Output unchanged. |
| `fix(schema)` | correctness | Nullable `$ref` fields now emit `anyOf: [{ $ref }, { type: "null" }]` instead of invalid `type: [undefined, "null"]`. Unified rule: primitives extend the `type` array as before. |
| `test(schema)` | cleanup | Array-field fixtures typed to match their decorators (`File[]`/`Folder[]`). Documents that a scalar circular ref must stay `object` under `emitDecoratorMetadata`. |

### Deliberately deferred
- **Change A (schema-option storage unification)** — lowest value / medium risk, no output change; deferred.
- **Phases 2–6** (coherence assertions with `throw` default, `paramtypes` resolver, `Infer<T>`, draft-2020-12 dialect, `@FieldMetadata` namespacing, new keywords, docs) — follow-up PRs.

### ⚠️ Pre-existing issue flagged (not fixed here)
`feat_error-api-2` (`b8deace`) calls `AppError.internal(...)`, which requires `@shadow-library/common >= 1.6.x`, but `package.json` peer range is `^1.0.18` and `bun.lock` pins `1.0.18` (no `AppError.internal`). A frozen install fails 3 tests. Bump the peer range + lockfile on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
